### PR TITLE
bugfix: replace `mqtt` with `paho-mqtt`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.6
-before_install: gem install bundler -v 2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     mqtt-influxdb-translator (0.1.0)
       influxdb (~> 0.5.0)
-      mqtt (~> 0.5.0)
+      paho-mqtt (~> 1.0.12)
 
 GEM
   remote: https://rubygems.org/
@@ -34,11 +34,11 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.5)
     method_source (1.0.0)
-    mqtt (0.5.0)
     nenv (0.3.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    paho-mqtt (1.0.12)
     parallel (1.19.1)
     parser (2.7.1.3)
       ast (~> 2.4.0)

--- a/mqtt-influx-translator.gemspec
+++ b/mqtt-influx-translator.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "influxdb", "~> 0.5.0"
-  spec.add_runtime_dependency "mqtt", "~> 0.5.0"
+  spec.add_runtime_dependency "paho-mqtt", "~> 1.0.12"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "guard"

--- a/spec/config/test.yml
+++ b/spec/config/test.yml
@@ -8,8 +8,12 @@ influxdb:
   time_precision: ns
   hosts:
     - influxdb.example.org
-mqtt:
-  host: test.mosquitto.org
+paho-mqtt:
+  host: hab.i.trombik.org
+  ssl: false
+  reconnect_delay: 10
+  client_id: mqtt-influxdb-translator
+  persistent: true
 log_level: DEBUG
 log_file: /dev/null
 topics:

--- a/spec/mqtt/influxdb/translator/daemon_spec.rb
+++ b/spec/mqtt/influxdb/translator/daemon_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe MQTT::InfluxDB::Translator::Daemon do
     # esp,mac_addr=A020A615E8E9,signal=36 1592277621000000000
 
     it "translate MQTT value to a list of name and data" do
-      name, data = obj.translate(nil, topic, value, now)
+      name, data = obj.translate(topic, value, now)
       expect(name).to eq "esp"
       expect(data[:values].key?("signal")).to be true
       expect(data[:values]["signal"]).to eq 36


### PR DESCRIPTION
`mqtt` gem does not implement reconnection, and nor provide a simple method to
catch connection error.